### PR TITLE
TrackShip for WooCommerce

### DIFF
--- a/includes/class-wc-trackship-admin.php
+++ b/includes/class-wc-trackship-admin.php
@@ -844,7 +844,7 @@ class WC_Trackship_Admin {
 		<?php
 		// uninstall_notice
 		$screen = get_current_screen();
-		$delivered_count = get_trackship_settings( 'ts_delivered_status', 1 ) ? wc_orders_count( 'delivered' ) : null;
+		$delivered_count = get_trackship_settings( 'ts_delivered_status', 1 ) && array_key_exists( 'wc-delivered', wc_get_order_statuses() ) ? wc_orders_count( 'delivered' ) : null;
 
 		if ( 'plugins.php' == $screen->parent_file && $delivered_count > 0 ) {
 			$order_statuses = wc_get_order_statuses();

--- a/includes/class-wc-trackship-front.php
+++ b/includes/class-wc-trackship-front.php
@@ -546,7 +546,9 @@ class WC_TrackShip_Front {
 						esc_html_e( $this->tracking_page_header( $order, $tracking_provider, $tracking_number, $tracker, $item, $trackind_detail_by_status_rev ) );
 						
 						esc_html_e( $this->tracking_progress_bar( $tracker ) );
-						
+
+						do_action( 'trackship_tracking_page_notice', $tracking_provider, $tracking_number, $order_id );
+
 						esc_html_e( $this->layout1_tracking_details( $trackind_detail_by_status_rev, $tracking_details_by_date, $trackind_destination_detail_by_status_rev, $tracking_destination_details_by_date, $tracker , $order_id, $tracking_provider, $tracking_number ) );
 
 						?>

--- a/includes/integration/class-woo-fulfillment-integration.php
+++ b/includes/integration/class-woo-fulfillment-integration.php
@@ -3,11 +3,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-use Automattic\WooCommerce\Internal\DataStores\Fulfillments\FulfillmentsDataStore;
-use Automattic\WooCommerce\Internal\Fulfillments\DTO\Fulfillment;
-// use Automattic\WooCommerce\Internal\Fulfillments\FulfillmentUtils;
-use Automattic\WooCommerce\Admin\Features\Fulfillments\FulfillmentUtils;
-
 class WOO_Fulfillment_Tracking_TS4WC {
 
 	/**
@@ -17,6 +12,8 @@ class WOO_Fulfillment_Tracking_TS4WC {
 	*/
 	private static $instance;
 	private $fulfillments_table_exists;
+	private $datastore_class_cache;
+	private $utils_class_cache;
 
 	/**
 	 * Private constructor to prevent direct instantiation.
@@ -44,7 +41,7 @@ class WOO_Fulfillment_Tracking_TS4WC {
 	 *
 	 * @param int $order_id WooCommerce order ID.
 	 *
-	 * @return Fulfillment[] Array of fulfillment DTOs (can be empty).
+	 * @return array Array of fulfillment objects (can be empty).
 	 */
 	public function get_fulfillments_by_order_id( $order_id ) {
 		$order_id = (int) $order_id;
@@ -57,12 +54,12 @@ class WOO_Fulfillment_Tracking_TS4WC {
 			return [];
 		}
 
-		if ( ! class_exists( FulfillmentsDataStore::class ) ) {
+		$datastore_class = $this->get_fulfillments_datastore_class();
+		if ( ! $datastore_class ) {
 			return [];
 		}
 
-		/** @var FulfillmentsDataStore $datastore */
-		$datastore = wc_get_container()->get( FulfillmentsDataStore::class );
+		$datastore = wc_get_container()->get( $datastore_class );
 
 		if ( ! $datastore ) {
 			return [];
@@ -98,13 +95,16 @@ class WOO_Fulfillment_Tracking_TS4WC {
 			}
 			$product_array = [];
 			$items = $fulfillment->get_meta( '_items', true );
-			foreach ( $items as $item_value ) {
-				$item_id = $item_value['item_id'];
+			foreach ( (array) $items as $item_value ) {
+				$item_id = $item_value['item_id'] ?? null;
+				if ( ! $item_id ) {
+					continue;
+				}
 				$item = $order->get_item( $item_id );
 				$product_array[] = (object) array(
 					'product'	=> $item ? $item->get_product_id() : null,
-					'item_id'	=> $item_value['item_id'],
-					'qty'		=> $item_value['qty'],
+					'item_id'	=> $item_id,
+					'qty'		=> $item_value['qty'] ?? 1,
 				);
 			}
 
@@ -119,7 +119,7 @@ class WOO_Fulfillment_Tracking_TS4WC {
 				'tracking_id'					=> '',
 				'date_shipped'					=> $fulfillment->get_meta( '_date_fulfilled', true ),
 				'products_list'					=> $product_array,
-				'tracking_provider_image'		=> $providers[ $shipment_provider ]['icon'] ?? null,
+				'tracking_provider_image'		=> $this->get_provider_image( $providers, $shipment_provider ),
 				'tracking_page_link'			=> trackship_for_woocommerce()->actions->get_tracking_page_link( $order_id, $tracking_number ),
 			);
 			$tracking_items[] = $tracking_item;
@@ -127,21 +127,83 @@ class WOO_Fulfillment_Tracking_TS4WC {
 		return $tracking_items;
 	}
 
+	/**
+	 * Returns the provider image, handling WC 10.6 (class name string) and WC 10.7+ (instantiated object).
+	 *
+	 * @param array|false $providers        Result of get_providers().
+	 * @param string      $shipment_provider Provider slug.
+	 * @return string|null
+	 */
+	private function get_provider_image( $providers, $shipment_provider ) {
+		if ( ! $providers || ! isset( $providers[ $shipment_provider ] ) ) {
+			return null;
+		}
+		$provider = $providers[ $shipment_provider ];
+		// WC 10.7+: provider is already an instantiated object
+		if ( is_object( $provider ) ) {
+			return method_exists( $provider, 'get_icon' ) ? $provider->get_icon() : null;
+		}
+		// WC 10.6: provider is a class name string — resolve via container to handle DI dependencies
+		if ( is_string( $provider ) && class_exists( $provider ) ) {
+			$instance = function_exists( 'wc_get_container' ) ? wc_get_container()->get( $provider ) : new $provider();
+			return ( $instance && method_exists( $instance, 'get_icon' ) ) ? $instance->get_icon() : null;
+		}
+		return null;
+	}
+
+	/**
+	 * Returns the available FulfillmentsDataStore class name, supporting WooCommerce 10.6 and 10.7+.
+	 *
+	 * @return string|null Fully-qualified class name, or null if neither exists.
+	 */
+	private function get_fulfillments_datastore_class() {
+		if ( $this->datastore_class_cache !== null ) {
+			return $this->datastore_class_cache;
+		}
+		if ( class_exists( 'Automattic\WooCommerce\Admin\Features\Fulfillments\DataStore\FulfillmentsDataStore' ) ) {
+			return $this->datastore_class_cache = 'Automattic\WooCommerce\Admin\Features\Fulfillments\DataStore\FulfillmentsDataStore';
+		}
+		if ( class_exists( 'Automattic\WooCommerce\Internal\DataStores\Fulfillments\FulfillmentsDataStore' ) ) {
+			return $this->datastore_class_cache = 'Automattic\WooCommerce\Internal\DataStores\Fulfillments\FulfillmentsDataStore';
+		}
+		return $this->datastore_class_cache = false;
+	}
+
+	/**
+	 * Returns the available FulfillmentUtils class name, supporting WooCommerce 10.6 and 10.7+.
+	 *
+	 * @return string|null Fully-qualified class name, or null if neither exists.
+	 */
+	private function get_fulfillment_utils_class() {
+		if ( $this->utils_class_cache !== null ) {
+			return $this->utils_class_cache;
+		}
+		if ( class_exists( 'Automattic\WooCommerce\Admin\Features\Fulfillments\FulfillmentUtils' ) ) {
+			return $this->utils_class_cache = 'Automattic\WooCommerce\Admin\Features\Fulfillments\FulfillmentUtils';
+		}
+		if ( class_exists( 'Automattic\WooCommerce\Internal\Fulfillments\FulfillmentUtils' ) ) {
+			return $this->utils_class_cache = 'Automattic\WooCommerce\Internal\Fulfillments\FulfillmentUtils';
+		}
+		return $this->utils_class_cache = false;
+	}
+
 	public function has_pending_items( $order_id ) {
-		if ( ! class_exists( FulfillmentUtils::class ) ) {
+		$utils_class = $this->get_fulfillment_utils_class();
+		if ( ! $utils_class ) {
 			return false;
 		}
 		$order = wc_get_order( $order_id );
 		$fulfillments = $this->get_fulfillments_by_order_id( $order_id );
 
-		return FulfillmentUtils::has_pending_items( $order, $fulfillments );
+		return $utils_class::has_pending_items( $order, $fulfillments );
 	}
 
 	public function get_providers() {
-		if ( ! class_exists( FulfillmentUtils::class ) ) {
+		$utils_class = $this->get_fulfillment_utils_class();
+		if ( ! $utils_class ) {
 			return false;
 		}
-		return FulfillmentUtils::get_shipping_providers();
+		return $utils_class::get_shipping_providers();
 	}
 
 	public function is_fulfillments_table_exists() {

--- a/includes/integration/class-woo-fulfillment-integration.php
+++ b/includes/integration/class-woo-fulfillment-integration.php
@@ -5,7 +5,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 use Automattic\WooCommerce\Internal\DataStores\Fulfillments\FulfillmentsDataStore;
 use Automattic\WooCommerce\Internal\Fulfillments\DTO\Fulfillment;
-use Automattic\WooCommerce\Internal\Fulfillments\FulfillmentUtils;
+// use Automattic\WooCommerce\Internal\Fulfillments\FulfillmentUtils;
+use Automattic\WooCommerce\Admin\Features\Fulfillments\FulfillmentUtils;
 
 class WOO_Fulfillment_Tracking_TS4WC {
 
@@ -127,6 +128,9 @@ class WOO_Fulfillment_Tracking_TS4WC {
 	}
 
 	public function has_pending_items( $order_id ) {
+		if ( ! class_exists( FulfillmentUtils::class ) ) {
+			return false;
+		}
 		$order = wc_get_order( $order_id );
 		$fulfillments = $this->get_fulfillments_by_order_id( $order_id );
 
@@ -134,7 +138,10 @@ class WOO_Fulfillment_Tracking_TS4WC {
 	}
 
 	public function get_providers() {
-		return FulfillmentUtils::get_shipping_providers_object();
+		if ( ! class_exists( FulfillmentUtils::class ) ) {
+			return false;
+		}
+		return FulfillmentUtils::get_shipping_providers();
 	}
 
 	public function is_fulfillments_table_exists() {

--- a/includes/trackship-email-manager.php
+++ b/includes/trackship-email-manager.php
@@ -61,8 +61,10 @@ class WC_TrackShip_Email_Manager {
 		);
 
 		$email_to = [];
-		if ( $enable && $for_amazon_order && '0' != $receive_email && $order->get_billing_email() ) {
-			$email_to[] = $order->get_billing_email();
+		$email_address = apply_filters( 'trackship_shipment_email_recipient', $order->get_billing_email(), $order );
+
+		if ( $enable && $for_amazon_order && '0' != $receive_email && $email_address ) {
+			$email_to[] = $email_address;
 		}
 		$email_to = apply_filters( 'add_multiple_emails_to_shipment_email', $email_to, $new_status );
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: WooCommerce, parcel tracking, woocommerce shipment tracking, order trackin
 Requires at least: 6.2
 Tested up to: 6.9.4
 Requires PHP: 7.4
-Stable tag: 2.0.2
+Stable tag: 2.0.3
 License: GPLv2 
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -153,6 +153,13 @@ No. You can fully test out TrackShip and all the features with the free trial Tr
 13. You can view TrackShip Analytics and filter results by time range, shipment status, or provider.
 
 == Changelog ==
+= 2.0.3 - 2026-04-15 =
+* Fix - Fixed fatal error with WooCommerce Fulfillments integration caused by class namespace changes in WooCommerce 10.7.
+* Fix - Added check for delivered status existence before counting orders.
+* New - Added filter for shipment email recipient: trackship_shipment_email_recipient.
+* New - Added custom hook to tracking page for notice: trackship_tracking_page_notice.
+* Compatibility - Verified compatibility with WooCommerce version 10.7.0.
+
 = 2.0.2 - 2026-03-27 =
 * Update - Translation updated.
 * Compatibility - Verified compatibility with WooCommerce version 10.6.1.
@@ -196,5 +203,5 @@ For a complete changelog history, please visit our [documentation](https://docs.
 
 == Upgrade Notice ==
 
-= 2.0.2 =
-Minor update. Translation updated. Verified compatibility with WooCommerce 10.6.1 and WordPress 6.9.4.
+= 2.0.3 =
+Fixed fatal error with WooCommerce Fulfillments on WooCommerce 10.7. Added filter for shipment email recipient and custom hook for tracking page notice.

--- a/trackship-for-woocommerce.php
+++ b/trackship-for-woocommerce.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: TrackShip for WooCommerce
  * Description: TrackShip for WooCommerce integrates TrackShip into your WooCommerce Store and auto-tracks your orders, automates your post-shipping workflow and allows you to provide a superior Post-Purchase experience to your customers.
- * Version: 2.0.2
+ * Version: 2.0.2.2
  * Author: TrackShip
  * Author URI: https://trackship.com/
  * License: GPL-2.0+
@@ -24,7 +24,7 @@ class Trackship_For_Woocommerce {
 	 *
 	 * @var string
 	*/
-	public $version = '2.0.2';
+	public $version = '2.0.2.2';
 	public $plugin_path;
 	public $ts_install;
 	public $ts_actions;

--- a/trackship-for-woocommerce.php
+++ b/trackship-for-woocommerce.php
@@ -2,14 +2,14 @@
 /**
  * Plugin Name: TrackShip for WooCommerce
  * Description: TrackShip for WooCommerce integrates TrackShip into your WooCommerce Store and auto-tracks your orders, automates your post-shipping workflow and allows you to provide a superior Post-Purchase experience to your customers.
- * Version: 2.0.2.3
+ * Version: 2.0.3
  * Author: TrackShip
  * Author URI: https://trackship.com/
  * License: GPL-2.0+
- * License URI: 
+ * License URI:
  * Text Domain: trackship-for-woocommerce
  * Domain Path: /language/
- * WC tested up to: 10.6.1
+ * WC tested up to: 10.7
  * Requires Plugins: woocommerce
 */
 
@@ -24,7 +24,7 @@ class Trackship_For_Woocommerce {
 	 *
 	 * @var string
 	*/
-	public $version = '2.0.2.3';
+	public $version = '2.0.3';
 	public $plugin_path;
 	public $ts_install;
 	public $ts_actions;

--- a/trackship-for-woocommerce.php
+++ b/trackship-for-woocommerce.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: TrackShip for WooCommerce
  * Description: TrackShip for WooCommerce integrates TrackShip into your WooCommerce Store and auto-tracks your orders, automates your post-shipping workflow and allows you to provide a superior Post-Purchase experience to your customers.
- * Version: 2.0.2.2
+ * Version: 2.0.2.3
  * Author: TrackShip
  * Author URI: https://trackship.com/
  * License: GPL-2.0+
@@ -24,7 +24,7 @@ class Trackship_For_Woocommerce {
 	 *
 	 * @var string
 	*/
-	public $version = '2.0.2.2';
+	public $version = '2.0.2.3';
 	public $plugin_path;
 	public $ts_install;
 	public $ts_actions;


### PR DESCRIPTION
### 2.0.3 - 2026-04-15

- Fix - Fixed fatal error with WooCommerce Fulfillments integration caused by class namespace changes in WooCommerce 10.7.
- Fix - Added check for delivered status existence before counting orders.
- New - Added filter for shipment email recipient: trackship_shipment_email_recipient.
- New - Added custom hook to tracking page for notice: trackship_tracking_page_notice.
- Compatibility - Verified compatibility with WooCommerce version 10.7.0.